### PR TITLE
Manage the communication with the LIFX

### DIFF
--- a/LIFX Test app/Form1.cs
+++ b/LIFX Test app/Form1.cs
@@ -131,10 +131,7 @@ namespace Lifx_Test_app
         private void button9_Click(object sender, EventArgs e)
         {
             colorDialog1.ShowDialog();
-            colorDialog1.Color = mBulbColorP.BackColor;
             mBulbColorP.BackColor = colorDialog1.Color;
-
-             
         }
 
         private void button8_Click(object sender, EventArgs e)

--- a/LIFX Test app/Form1.cs
+++ b/LIFX Test app/Form1.cs
@@ -15,7 +15,8 @@ namespace Lifx_Test_app
 {
     public partial class Form1 : Form
     {
-        LifxBulb mBulb;
+        //LifxBulb mBulb;
+        LifxPanController mPanController;
 
         public Form1()
         {
@@ -39,18 +40,18 @@ namespace Lifx_Test_app
                 return;            
             }
 
-            mBulb = panController[0].Bulbs[0];
+            mPanController = panController[0];
 
-            mBulbIPTB.Text = mBulb.IpEndpoint.Address.ToString(); 
-            mTargetMACTB.Text = mBulb.MacAddress;
-            mPANControllerTB.Text = mBulb.PanHandler;
+            mBulbIPTB.Text = mPanController.IpEndpoint.Address.ToString();
+            mTargetMACTB.Text = mPanController.MacAddress;
+            mPANControllerTB.Text = mPanController.MacAddress;
 
-            LifxPowerState powerState = mBulb.GetPowerState();
+            //LifxPowerState powerState = mPanController.GetPowerState();
 
-            if (powerState == LifxPowerState.On)
-                mPowerStateOnCB.Checked = true;
-            else
-                mPowerStateOnCB.Checked = false;
+            //if (powerState == LifxPowerState.On)
+            //    mPowerStateOnCB.Checked = true;
+            //else
+            //    mPowerStateOnCB.Checked = false;
 
             mPowerGB.Enabled = true;
             mLabelsGB.Enabled = true;
@@ -68,7 +69,7 @@ namespace Lifx_Test_app
 
         private void SetPowerState(LifxPowerState state)
         {
-            mBulb.SetPowerState(state);
+            mPanController.SetPowerState(state);
         }
 
         private void button3_Click(object sender, EventArgs e)
@@ -89,12 +90,12 @@ namespace Lifx_Test_app
 
         private void button4_Click(object sender, EventArgs e)
         {
-            mLabelTB.Text = mBulb.GetLabel();
+            mLabelTB.Text = mPanController.GetLabel();
         }
 
         private void button5_Click(object sender, EventArgs e)
         {
-            mLabelTB.Text = mBulb.SetLabel(mLabelTB.Text);
+            mLabelTB.Text = mPanController.SetLabel(mLabelTB.Text);
         }
 
         private void button6_Click(object sender, EventArgs e)
@@ -138,7 +139,7 @@ namespace Lifx_Test_app
 
         private void button8_Click(object sender, EventArgs e)
         {
-            LifxLightStatus status = mBulb.GetLightStatus();
+            LifxLightStatus status = mPanController.GetLightStatus();
 
             mBulbColorP.BackColor = status.Color.DotNetColor;
             mKelvinTB.Text = status.Color.Kelvin.ToString();
@@ -162,7 +163,7 @@ namespace Lifx_Test_app
                 return;
             }
 
-            mBulb.SetColor(new LifxColor(mBulbColorP.BackColor, kelvinValue), fadeTime);
+            mPanController.SetColor(new LifxColor(mBulbColorP.BackColor, kelvinValue), fadeTime);
 
         }
 
@@ -183,7 +184,7 @@ namespace Lifx_Test_app
                 return;
             }
 
-            mBulb.SetDimLevel(dimLevel, fadeTime);
+            mPanController.SetDimLevel(dimLevel, fadeTime);
         }
 
         private void Form1_FormClosing(object sender, FormClosingEventArgs e)

--- a/LifxLib/LifxCommunicator.cs
+++ b/LifxLib/LifxCommunicator.cs
@@ -195,7 +195,7 @@ namespace LifxLib
 
             LifxDataPacket packet = new LifxDataPacket(command);
             packet.TargetMac = LifxHelper.StringToByteArray(macAddress);
-            packet.PanControllerMac = LifxHelper.StringToByteArray(panController);
+            packet.PanControllerMac = LifxHelper.StringToByteArray(""); //PanControllerMac has to be set to 0.0.0.0 to monnunicate with the LIFX
 
             client.Send(packet.PacketData, packet.PacketData.Length);
 
@@ -234,9 +234,10 @@ namespace LifxLib
                         LifxLightStatusMessage panGateway = new LifxLightStatusMessage();
                         panGateway.ReceivedData = receivedPacket;
 
-                        AddDiscoveredBulb(
-                            LifxHelper.ByteArrayToString(receivedPacket.TargetMac),   
-                            LifxHelper.ByteArrayToString(receivedPacket.PanControllerMac));
+                        /* Bulbs is no longer needed but I do not delate it 'just in case' */
+                        //AddDiscoveredBulb(
+                        //    LifxHelper.ByteArrayToString(receivedPacket.TargetMac),   
+                        //    LifxHelper.ByteArrayToString(receivedPacket.PanControllerMac));
                     }
                     else if (receivedPacket.PacketType == command.ReturnMessage.PacketType)
                     {
@@ -276,25 +277,27 @@ namespace LifxLib
             mFoundPanHandlers.Add(foundPanHandler);
         }
 
-        private void AddDiscoveredBulb(string macAddress, string panController)
-        {
-            foreach (LifxPanController controller in mFoundPanHandlers)
-            {
-                if (controller.MacAddress == panController)
-                {
-                    foreach (LifxBulb bulb in controller.Bulbs)
-                    {
-                        if (bulb.MacAddress == macAddress)
-                            return;
-                    }
+        /* Bulbs is no longer needed but I do not delate it 'just in case' */
 
-                    controller.Bulbs.Add(new LifxBulb(controller, macAddress));
-                    return;
-                }
-            }
+        //private void AddDiscoveredBulb(string macAddress, string panController)
+        //{
+        //    foreach (LifxPanController controller in mFoundPanHandlers)
+        //    {
+        //        if (controller.MacAddress == panController)
+        //        {
+        //            foreach (LifxBulb bulb in controller.Bulbs)
+        //            {
+        //                if (bulb.MacAddress == macAddress)
+        //                    return;
+        //            }
 
-            throw new InvalidOperationException("Should not end up here basically.");
-        }
+        //            controller.Bulbs.Add(new LifxBulb(controller, macAddress));
+        //            return;
+        //        }
+        //    }
+
+        //    throw new InvalidOperationException("Should not end up here basically.");
+        //}
 
 
         private UdpClient GetConnectedClient(LifxCommand command, IPEndPoint endPoint)

--- a/LifxLib/LifxPanController.cs
+++ b/LifxLib/LifxPanController.cs
@@ -17,11 +17,13 @@ namespace LifxLib
     {
         private string mMacAddress = "";        
         private IPEndPoint mIpAddress;
-#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3)
-        ArrayList mBulbs = new ArrayList();
-#else
-        List<LifxBulb> mBulbs = new List<LifxBulb>();
-#endif
+
+        /* Bulbs is no longer needed but I do not delate it 'just in case' */
+//#if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3)
+//        ArrayList mBulbs = new ArrayList();
+//#else
+//        List<LifxBulb> mBulbs = new List<LifxBulb>();
+//#endif
        
         public LifxPanController(string macAddress, IPEndPoint ipAddress)
         {
@@ -29,93 +31,89 @@ namespace LifxLib
             mIpAddress = ipAddress;
         }
 
-        ///// <summary>
-        ///// Get current power state
-        ///// </summary>
-        ///// <returns></returns>
-        //public LifxPowerState GetPowerState()
-        //{
-        //    LifxGetPowerStateCommand command = new LifxGetPowerStateCommand();
+        /// <summary>
+        /// Get current power state
+        /// </summary>
+        /// <returns></returns>
+        public LifxPowerState GetPowerState()
+        {
+            LifxGetPowerStateCommand command = new LifxGetPowerStateCommand();
 
-        //    LifxCommunicator.Instance.SendCommand(command, this);
-        //    LifxPowerStateMessage returnMessage = (LifxPowerStateMessage)command.ReturnMessage;
+            LifxCommunicator.Instance.SendCommand(command, this);
+            LifxPowerStateMessage returnMessage = (LifxPowerStateMessage)command.ReturnMessage;
 
-        //    return returnMessage.PowerState;
-        //}
+            return returnMessage.PowerState;
+        }
 
-        ///// <summary>
-        ///// Set current power state
-        ///// </summary>
-        ///// <param name="stateToSet"></param>
-        ///// <returns>Returns the set power state</returns>
-        //public LifxPowerState SetPowerState(LifxPowerState stateToSet)
-        //{
-        //    LifxSetPowerStateCommand command = new LifxSetPowerStateCommand(stateToSet);
+        /// <summary>
+        /// Set current power state
+        /// </summary>
+        /// <param name="stateToSet"></param>
+        /// <returns>Returns the set power state</returns>
+        public void SetPowerState(LifxPowerState stateToSet)
+        {
+            LifxSetPowerStateCommand command = new LifxSetPowerStateCommand(stateToSet);
 
-        //    LifxCommunicator.Instance.SendCommand(command, this);
+            LifxCommunicator.Instance.SendCommand(command, this);
+        }
 
-        //    LifxPowerStateMessage returnMessage = (LifxPowerStateMessage)command.ReturnMessage;
+        public string GetLabel()
+        {
 
-        //    return returnMessage.PowerState;
-        //}
+            LifxGetLabelCommand command = new LifxGetLabelCommand();
+            LifxCommunicator.Instance.SendCommand(command, this);
 
-        //public string GetLabel()
-        //{
-
-        //    LifxGetLabelCommand command = new LifxGetLabelCommand();
-        //    LifxCommunicator.Instance.SendCommand(command, this);
-
-        //    return ((LifxLabelMessage)command.ReturnMessage).BulbLabel;
-        //}
+            return ((LifxLabelMessage)command.ReturnMessage).BulbLabel;
+        }
 
 
-        //public string SetLabel(string newLabel)
-        //{
-        //    LifxSetLabelCommand command = new LifxSetLabelCommand(newLabel);
+        public string SetLabel(string newLabel)
+        {
+            LifxSetLabelCommand command = new LifxSetLabelCommand(newLabel);
 
-        //    LifxCommunicator.Instance.SendCommand(command, this);
+            LifxCommunicator.Instance.SendCommand(command, this);
 
-        //    return ((LifxLabelMessage)command.ReturnMessage).BulbLabel;
-        //}
+            return GetLabel();
+        }
 
-        //public LifxLightStatus GetLightStatus()
-        //{
+        public LifxLightStatus GetLightStatus()
+        {
 
-        //    LifxGetLightStatusCommand command = new LifxGetLightStatusCommand();
+            LifxGetLightStatusCommand command = new LifxGetLightStatusCommand();
 
-        //    LifxCommunicator.Instance.SendCommand(command, this);
+            LifxCommunicator.Instance.SendCommand(command, this);
 
-        //    LifxLightStatusMessage lsMessage = (LifxLightStatusMessage)command.ReturnMessage;
+            LifxLightStatusMessage lsMessage = (LifxLightStatusMessage)command.ReturnMessage;
 
-        //    //HSLColor hslColor = new HSLColor((double)(lsMessage.Hue * 240 / 65535), (double)(lsMessage.Saturation * 240 / 65535), (double)(lsMessage.Lumnosity * 240 / 65535));
+            //HSLColor hslColor = new HSLColor((double)(lsMessage.Hue * 240 / 65535), (double)(lsMessage.Saturation * 240 / 65535), (double)(lsMessage.Lumnosity * 240 / 65535));
 
-        //    LifxColor color = new LifxColor(lsMessage.Hue, lsMessage.Saturation, lsMessage.Lumnosity, lsMessage.Kelvin);
+            LifxColor color = new LifxColor(lsMessage.Hue, lsMessage.Saturation, lsMessage.Lumnosity, lsMessage.Kelvin);
 
-        //    LifxLightStatus lightsStatus = new LifxLightStatus(color, lsMessage.PowerState, lsMessage.Dim, lsMessage.Label, lsMessage.Tags);
+            LifxLightStatus lightsStatus = new LifxLightStatus(color, lsMessage.PowerState, lsMessage.Dim, lsMessage.Label, lsMessage.Tags);
 
-        //    return lightsStatus;
-                
-        //}
+            return lightsStatus;
 
-
-        //public void SetColor(LifxColor color, UInt32 fadeTime)
-        //{
-
-        //    LifxSetLightStateCommand command = new LifxSetLightStateCommand(color.Hue, color.Saturation, color.Lumnosity, color.Kelvin, fadeTime);
-
-        //    LifxCommunicator.Instance.SendCommand(command, this);
-        
-        //}
+        }
 
 
-        //public void SetDimLevel(UInt16 dimLevel, UInt32 fadeTime)
-        //{
+        public void SetColor(LifxColor color, UInt32 fadeTime)
+        {
 
-        //    LifxSetDimAbsoluteCommand command = new LifxSetDimAbsoluteCommand(dimLevel, fadeTime);
+            LifxSetLightStateCommand command = new LifxSetLightStateCommand(color.Hue, color.Saturation, color.Lumnosity, color.Kelvin, fadeTime);
 
-        //    LifxCommunicator.Instance.SendCommand(command, this);
+            LifxCommunicator.Instance.SendCommand(command, this);
 
-        //}
+        }
+
+
+        public void SetDimLevel(UInt16 dimLevel, UInt32 fadeTime)
+        {
+
+            LifxSetDimAbsoluteCommand command = new LifxSetDimAbsoluteCommand(dimLevel, fadeTime);
+
+            LifxCommunicator.Instance.SendCommand(command, this);
+
+        }
 
 
         /// <summary>
@@ -147,15 +145,16 @@ namespace LifxLib
             get { return mIpAddress; }
             set { mIpAddress = value; }
         }
-      
- #if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3)
-        public ArrayList Bulbs
-#else
-        public List<LifxBulb> Bulbs
-#endif
-    {
-            get { return mBulbs; }
-            set { mBulbs = value; }
-        }
+
+        /* Bulbs is no longer needed but I do not delate it 'just in case' */
+// #if (MF_FRAMEWORK_VERSION_V4_2 || MF_FRAMEWORK_VERSION_V4_3)
+//        public ArrayList Bulbs
+//#else
+//        public List<LifxBulb> Bulbs
+//#endif
+//    {
+//            get { return mBulbs; }
+//            set { mBulbs = value; }
+//        }
     }
 }

--- a/LifxLib/Messages/Commands/LifxSetLabelCommand.cs
+++ b/LifxLib/Messages/Commands/LifxSetLabelCommand.cs
@@ -17,7 +17,7 @@ namespace LifxLib.Messages
 
        
         public LifxSetLabelCommand(string newLabelName)
-            : base(PACKET_TYPE, new LifxLabelMessage())
+            : base(PACKET_TYPE, null)
         {
             mLabelName = newLabelName;    
         }

--- a/LifxLib/Messages/Commands/LifxSetPowerStateCommand.cs
+++ b/LifxLib/Messages/Commands/LifxSetPowerStateCommand.cs
@@ -15,7 +15,7 @@ namespace LifxLib.Messages
         private const UInt16 PACKET_TYPE = 0x15;
 
         public LifxSetPowerStateCommand(LifxPowerState stateToSet)
-            : base(PACKET_TYPE, new LifxPowerStateMessage())
+            : base(PACKET_TYPE, null)
         {
             mStateToSet = stateToSet;
         }

--- a/LifxLib/Messages/Commands/LifxSetTagsCommand.cs
+++ b/LifxLib/Messages/Commands/LifxSetTagsCommand.cs
@@ -16,7 +16,7 @@ namespace LifxLib.Messages
 
 
         public LifxSetTagsCommand(UInt64 tagsValue)
-            : base(PACKET_TYPE, new LifxTagsMessage())
+            : base(PACKET_TYPE, null)
         {
             mTagsValue = tagsValue;
         }


### PR DESCRIPTION
- Use PanController instead of Bulb to send commands
- Set PanController MacAdress to 0.0.0.0 to communicate with the LIFX
- Setter Commands do not need responses from the LIFX anymore
